### PR TITLE
Added the ability to adjust the color of the background bar plot border.

### DIFF
--- a/R/ggsegmentedtotalbar.R
+++ b/R/ggsegmentedtotalbar.R
@@ -17,6 +17,7 @@ utils::globalVariables(".data")
 #' @param total A string specifying the column name for the total variable (used for determining the background box height).
 #' @param alpha A numeric value (between 0 and 1) controlling the transparency of the background boxes. Default is 0.3.
 #' @param color A string specifying the color of the background boxes. Default is "lightgrey".
+#' @param border_color A string specifying the border color of the background boxes. Default is "black".
 #' @param label Logical. If `TRUE`, adds labels showing total values above the boxes and value labels on each segment. Default is `FALSE`.
 #' @param label_size Numeric. Text size for the labels. Default is 4.
 #' @param label_color A string specifying the color of the labels. Default is "black".
@@ -35,7 +36,7 @@ utils::globalVariables(".data")
 #'
 #' @export
 ggsegmentedtotalbar <- function(df, group, segment, value, total,
-                                alpha = 0.3, color = "lightgrey",
+                                alpha = 0.3, color = "lightgrey", border_color = "black",
                                 label = FALSE, label_size = 4, label_color = "black") {
 
   # Order group variable by total value
@@ -53,7 +54,7 @@ ggsegmentedtotalbar <- function(df, group, segment, value, total,
     current_category <- levels(df[[group]])[i]
     y_value <- df[[total]][df[[group]] == current_category][1]
     ggplot2::annotation_custom(
-      grob = grid::rectGrob(gp = grid::gpar(fill = color, alpha = alpha)),
+      grob = grid::rectGrob(gp = grid::gpar(col = border_color, fill = color, alpha = alpha)),
       xmin = i - 0.47, xmax = i + 0.47,
       ymin = 0, ymax = y_value
     )

--- a/man/ggsegmentedtotalbar.Rd
+++ b/man/ggsegmentedtotalbar.Rd
@@ -12,6 +12,7 @@ ggsegmentedtotalbar(
   total,
   alpha = 0.3,
   color = "lightgrey",
+  border_color = "black",
   label = FALSE,
   label_size = 4,
   label_color = "black"
@@ -31,6 +32,8 @@ ggsegmentedtotalbar(
 \item{alpha}{A numeric value (between 0 and 1) controlling the transparency of the background boxes. Default is 0.3.}
 
 \item{color}{A string specifying the color of the background boxes. Default is "lightgrey".}
+
+\item{border_color}{A string specifying the border color of the background boxes. Default is "black".}
 
 \item{label}{Logical. If `TRUE`, adds labels showing total values above the boxes and value labels on each segment. Default is `FALSE`.}
 


### PR DESCRIPTION
Dear Developer

Thank you for a very unique and useful package.

Currently, the color of the border of the segment total bar (background bar) cannot be changed and is black.

This does not bother me when the background bar color is the default gray, but I would like to change the border color when it is changed to a non-default, particularly vivid color.

I have Pull Requested a simple code that adds that functionality.

When executed, it behaves as follows.

```r
df_ex <- data.frame(
  group = c("A", "A","A","B", "B","B","C","C","C","D","D","D"),
  segment = c("X","Y","Z", "X","Y","Z", "X","Y","Z","X","Y","Z"),
  value = c(10, 20, 30, 40,50,60, 70,80,90, 100, 110, 120),
  total = c(60,60,60, 150,150,150, 240,240,240, 360,360,360)
)

ggsegmentedtotalbar(df_ex, "group", "segment", "value", "total", color = "pink", border_color = "red")
```

![image](https://github.com/user-attachments/assets/62c96ee7-1ee6-4671-b54e-7fb47e529651)
