### PR TITLE
Added functions to support sort order other than descending order of totals.

### DIFF
--- a/R/ggsegmentedtotalbar.R
+++ b/R/ggsegmentedtotalbar.R
@@ -20,6 +20,8 @@ utils::globalVariables(".data")
 #' @param label Logical. If `TRUE`, adds labels showing total values above the boxes and value labels on each segment. Default is `FALSE`.
 #' @param label_size Numeric. Text size for the labels. Default is 4.
 #' @param label_color A string specifying the color of the labels. Default is "black".
+#' @param reoder Logical. If `TRUE`, sort by total value in ascending or descending order. The sorting behavior is specified in .desc.
+#' @param .desc Logical. If `TRUE`, sort in descending order by total value.
 #'
 #' @return A ggplot object displaying the segmented bar plot with optional annotations and labels.
 #'
@@ -36,10 +38,12 @@ utils::globalVariables(".data")
 #' @export
 ggsegmentedtotalbar <- function(df, group, segment, value, total,
                                 alpha = 0.3, color = "lightgrey",
-                                label = FALSE, label_size = 4, label_color = "black") {
+                                label = FALSE, label_size = 4, label_color = "black",
+                                reoder = TRUE, .desc = TRUE) {
 
   # Order group variable by total value
-  df[[group]] <- forcats::fct_reorder(df[[group]], df[[total]], .fun = max, .desc = TRUE)
+  if(reoder) df[[group]] <- forcats::fct_reorder(df[[group]], df[[total]], .fun = max, .desc = .desc)
+  else if(!is.factor(df[[group]])) df[[group]] <- as.factor(df[[group]])
 
   # Base plot
   p <- ggplot2::ggplot(df, ggplot2::aes(x = .data[[group]], y = .data[[value]], fill = .data[[segment]])) +

--- a/man/ggsegmentedtotalbar.Rd
+++ b/man/ggsegmentedtotalbar.Rd
@@ -14,7 +14,9 @@ ggsegmentedtotalbar(
   color = "lightgrey",
   label = FALSE,
   label_size = 4,
-  label_color = "black"
+  label_color = "black",
+  reoder = TRUE,
+  .desc = TRUE
 )
 }
 \arguments{
@@ -37,6 +39,10 @@ ggsegmentedtotalbar(
 \item{label_size}{Numeric. Text size for the labels. Default is 4.}
 
 \item{label_color}{A string specifying the color of the labels. Default is "black".}
+
+\item{reoder}{Logical. If `TRUE`, sort by total value in ascending or descending order. The sorting behavior is specified in .desc.}
+
+\item{.desc}{Logical. If `TRUE`, sort in descending order by total value.}
 }
 \value{
 A ggplot object displaying the segmented bar plot with optional annotations and labels.


### PR DESCRIPTION
Dear Developer

Thank you for a very unique and useful package.

Currently, only descending order of total values is supported, but we would like to see support for graphing in ascending or arbitrary order. For example, in Japan, the fiscal year begins in April, and this culture is widely shared and often expected to begin in April for graphing.

For this reason, we are requesting pull requests for code that adds support for arbitrary sort order or ascending order.

Executing this code will result in the following;

```r
set.seed(123)

df_ex <- data.frame(
  group = factor(rep(c("1-3", "4-6", "7-9", "9-12"), 3), levels = c("4-6", "7-9", "9-12", "1-3")),
  segment = rep(c("A", "B", "C"), each = 4),
  value = sample(100:200, 4 * 3, replace = TRUE)
)

df_ex[["total"]] <- sapply(df_ex[["group"]], function(x) sum(df_ex[["value"]][df_ex[["group"]] == x]))

ggsegmentedtotalbar(df_ex, "group", "segment", "value", "total", reoder = FALSE, label = TRUE, .desc = FALSE) +
  ggplot2::xlab("month")
```

![image](https://github.com/user-attachments/assets/13448f5c-cbe7-4391-8d86-f600c2a1794b)
