### PR TITLE
Added support for negative values and the ability to adjust label positions and other details accordingly.

### DIFF
--- a/R/ggsegmentedtotalbar.R
+++ b/R/ggsegmentedtotalbar.R
@@ -17,7 +17,10 @@ utils::globalVariables(".data")
 #' @param total A string specifying the column name for the total variable (used for determining the background box height).
 #' @param alpha A numeric value (between 0 and 1) controlling the transparency of the background boxes. Default is 0.3.
 #' @param color A string specifying the color of the background boxes. Default is "lightgrey".
-#' @param label Logical. If `TRUE`, adds labels showing total values above the boxes and value labels on each segment. Default is `FALSE`.
+#' @param value_label Logical. If `TRUE`, adds labels showing values on each segment. Default is `FALSE`.
+#' @param total_label Logical. If `TRUE`, adds labels showing total values above the boxes. Default is same as `value_lavel`.
+#' @param value_vjust Numeric. adjust the alignment of values labels. Default is -0.3.
+#' @param total_vjust Numeric. adjust the alignment of total values labels. Default is -0.5.
 #' @param label_size Numeric. Text size for the labels. Default is 4.
 #' @param label_color A string specifying the color of the labels. Default is "black".
 #'
@@ -31,22 +34,33 @@ utils::globalVariables(".data")
 #'   total = rep(c(739, 692, 503, 392), each = 3)
 #' )
 #' ggsegmentedtotalbar(df_ex, group = "group", segment = "segment",
-#'                     value = "value", total = "total", label = TRUE)
+#'                     value = "value", total = "total", value_label = TRUE)
 #'
 #' @export
 ggsegmentedtotalbar <- function(df, group, segment, value, total,
                                 alpha = 0.3, color = "lightgrey",
-                                label = FALSE, label_size = 4, label_color = "black") {
+                                value_label = FALSE, total_label = value_label,
+                                value_vjust = -0.3, total_vjust = -0.5,
+                                label_size = 4, label_color = "black") {
 
   # Order group variable by total value
   df[[group]] <- forcats::fct_reorder(df[[group]], df[[total]], .fun = max, .desc = TRUE)
+
+  y_max <- max(df[[value]], df[[total]], na.rm = TRUE)
+  y_min <- min(df[[value]], df[[total]], na.rm = TRUE)
+
+  if(y_max >= 0) y_max <- round(y_max + y_max * 0.15)
+  else y_max <- 0
+
+  if(y_min >= 0) y_min <- 0
+  else y_min <- round(y_min + y_min * 0.15)
 
   # Base plot
   p <- ggplot2::ggplot(df, ggplot2::aes(x = .data[[group]], y = .data[[value]], fill = .data[[segment]])) +
     ggplot2::geom_col(position = ggplot2::position_dodge(width = 0.9)) +
     ggplot2::labs(title = "Segmented Total Bar Plot") +
     ggplot2::theme_minimal() +
-    ggplot2::ylim(0, round(max(df[[total]]) + max(df[[total]]) * 0.15))
+    ggplot2::ylim(y_min, y_max)
 
   # Background boxes (rectGrob)
   box_grobs <- lapply(seq_along(levels(df[[group]])), function(i) {
@@ -63,7 +77,7 @@ ggsegmentedtotalbar <- function(df, group, segment, value, total,
   p_final <- Reduce(`+`, c(list(p), box_grobs))
 
   # Add labels if requested
-  if (label) {
+  if (total_label) {
     # Total labels (one per group)
     label_data_total <- df[!duplicated(df[[group]]), c(group, total)]
     label_data_total[[group]] <- factor(label_data_total[[group]], levels = levels(df[[group]]))
@@ -72,10 +86,13 @@ ggsegmentedtotalbar <- function(df, group, segment, value, total,
       ggplot2::geom_text(data = label_data_total,
                          ggplot2::aes(x = .data[[group]], y = .data[[total]], label = .data[[total]]),
                          inherit.aes = FALSE,
-                         vjust = -0.5, size = label_size, color = label_color) +
+                         vjust = ifelse(label_data_total[[total]] >= 0, total_vjust, 1 - total_vjust), size = label_size, color = label_color)
+  }
+  if (value_label) {
+    p_final <- p_final +
       ggplot2::geom_text(ggplot2::aes(label = .data[[value]]),
                          position = ggplot2::position_dodge(width = 0.9),
-                         vjust = -0.3, size = label_size, color = label_color)
+                         vjust = ifelse(df[[value]] >= 0, value_vjust, 1 - value_vjust), size = label_size, color = label_color)
   }
 
   return(p_final)

--- a/man/ggsegmentedtotalbar.Rd
+++ b/man/ggsegmentedtotalbar.Rd
@@ -12,7 +12,10 @@ ggsegmentedtotalbar(
   total,
   alpha = 0.3,
   color = "lightgrey",
-  label = FALSE,
+  value_label = FALSE,
+  total_label = value_label,
+  value_vjust = -0.3,
+  total_vjust = -0.5,
   label_size = 4,
   label_color = "black"
 )
@@ -32,7 +35,13 @@ ggsegmentedtotalbar(
 
 \item{color}{A string specifying the color of the background boxes. Default is "lightgrey".}
 
-\item{label}{Logical. If `TRUE`, adds labels showing total values above the boxes and value labels on each segment. Default is `FALSE`.}
+\item{value_label}{Logical. If `TRUE`, adds labels showing values on each segment. Default is `FALSE`.}
+
+\item{total_label}{Logical. If `TRUE`, adds labels showing total values above the boxes. Default is same as `value_lavel`.}
+
+\item{value_vjust}{Numeric. adjust the alignment of values labels. Default is -0.3.}
+
+\item{total_vjust}{Numeric. adjust the alignment of total values labels. Default is -0.5.}
 
 \item{label_size}{Numeric. Text size for the labels. Default is 4.}
 
@@ -59,6 +68,6 @@ df_ex <- data.frame(
   total = rep(c(739, 692, 503, 392), each = 3)
 )
 ggsegmentedtotalbar(df_ex, group = "group", segment = "segment",
-                    value = "value", total = "total", label = TRUE)
+                    value = "value", total = "total", value_label = TRUE)
 
 }

--- a/vignettes/vignette.Rmd
+++ b/vignettes/vignette.Rmd
@@ -53,12 +53,12 @@ The function also provides three parameters that you can use to customize the pl
   
 - `alpha`: A numeric value (between 0 and 1) controlling the transparency of the background boxes. Default is 0.3.
 - `color`: A string specifying the color of the background boxes. Default is "lightgrey".
-- `label`: Logical. If `TRUE`, adds labels showing total values above the boxes and value labels on each segment. Default is `FALSE`.
+- `value_label`: Logical. If `TRUE`, adds labels showing total values above the boxes and value labels on each segment. Default is `FALSE`.
 
 ```{r example2}
 # Create the segmented total bar plot with labels
 p <- ggsegmentedtotalbar(df_ex, "group", "segment", "value", "total",
-                         label = TRUE, label_size = 4, label_color = "black")
+                         value_label = TRUE, label_size = 4, label_color = "black")
 # Print the plot
 print(p)
 ```
@@ -66,7 +66,7 @@ print(p)
 ```{r example3}
 # Create the segmented total bar plot with labels and different total box. 
 p <- ggsegmentedtotalbar(df_ex, "group", "segment", "value", "total",
-                         label = TRUE, label_size = 4, label_color = "black",
+                         value_label = TRUE, label_size = 4, label_color = "black",
                          alpha = 0.2, color = "steelblue")
 # Print the plot
 print(p)
@@ -77,7 +77,7 @@ Apart from these parameters, you can also customize your plot by utilizing ```gg
 ```{r example4}
 # Create the segmented total bar plot with labels and different total box.
 p <- ggsegmentedtotalbar(df_ex, "group", "segment", "value", "total",
-                         label = TRUE, label_size = 4, label_color = "black",
+                         value_label = TRUE, label_size = 4, label_color = "black",
                          alpha = 0.2, color = "steelblue") +
   ggplot2::labs(title = "Segmented Total Bar Plot with Custom Annotations",
                 x = "Group", y= "Value") +


### PR DESCRIPTION
@ozancanozdemir 
Dear Developer

Thank you for a very unique and useful package.

The current `ggsegmentedtotalbar()` does not draw the value correctly when it contains a negative value.

Of course, we could use an additional `ggplot2::ylim()` to adjust the drawing range, but we thought it would be better if the values were drawn correctly from the beginning.

I will suggest the code for negative values in a Pull Request. When negative values are included, I have also added a simple label positioning and drawing adjustment feature since there is a possibility that the total value label may overlap with the label for each value when the value labels are drawn.

An example execution of this code is shown below.

```r
df_ex <- data.frame(
  group = c("A", "A","A","B", "B","B","C","C","C","D","D","D"),
  segment = c("X","Y","Z", "X","Y","Z", "X","Y","Z","X","Y","Z"),
  value = c(-10, -20, -30, -40,-50,-60, -70,-80,-90, -100, -110, -120),
  total = c(-60, -60, -60, -150,-150,-150, -240,-240,-240, -360,-360,-360)
)
ggsegmentedtotalbar(df_ex, "group", "segment", "value", "total", total_label = TRUE)
```

<img width="653" height="542" alt="image" src="https://github.com/user-attachments/assets/49336a26-f0e1-4cc5-90d6-f8e93015452e" />

```r
ggsegmentedtotalbar(df_ex, "group", "segment", "value", "total", value_label = TRUE)
```

<img width="653" height="542" alt="image" src="https://github.com/user-attachments/assets/5d803f9d-18a2-4d6b-831e-7a65266bad20" />

```r
# Example of overlap between the total value and the label of each value
df_ex <- data.frame(
  group = c("A", "A","A","B", "B","B","C","C","C","D","D","D"),
  segment = c("X","Y","Z", "X","Y","Z", "X","Y","Z","X","Y","Z"),
  value = c(30, 20, -30, -40,-50,-60, -70,-80,-90, -100, -110, -120),
  total = c(20, 20, 20, -150,-150,-150, -240,-240,-240, -360,-360,-360)
)
ggsegmentedtotalbar(df_ex, "group", "segment", "value", "total", value_label = TRUE)
```

<img width="653" height="542" alt="image" src="https://github.com/user-attachments/assets/6444bf73-ce36-4c38-8598-998df226d2e1" />

```r
# Example of a simple displacement of the total label position
ggsegmentedtotalbar(df_ex, "group", "segment", "value", "total", value_label = TRUE, total_vjust = -1.5)
```

<img width="653" height="542" alt="image" src="https://github.com/user-attachments/assets/7c925bc0-fecc-49d2-8ddc-b48cefb48a79" />
